### PR TITLE
Solved the import error

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install st-annotated-text
 
 ```python
 import streamlit as st
-from st_annotated_text import annotated_text
+from annotated_text import annotated_text
 
 """
 # Annotated text example


### PR DESCRIPTION
The library is being installed as "annotated_text", not "st_annotated_text", therefore example provided in readme file showcasing how to use the module is not working, therefore I have updated it.