### PR TITLE
Take list as argument : updated __init__.py to handle list, added test script to test

### DIFF
--- a/annotated_text/__init__.py
+++ b/annotated_text/__init__.py
@@ -119,6 +119,7 @@ def annotated_text(*args):
     """
     out = div()
 
+
     for arg in args:
         if isinstance(arg, str):
             out(html.escape(arg))
@@ -128,6 +129,18 @@ def annotated_text(*args):
 
         elif isinstance(arg, tuple):
             out(annotation(*arg))
+
+        elif isinstance(arg,list):
+            for el in arg:
+                if isinstance(el, str):
+                    out(html.escape(el))
+
+                elif isinstance(el, HtmlElement):
+                    out(el)
+
+                elif isinstance(el, tuple):
+                    out(annotation(*el))
+
 
         else:
             raise Exception("Oh noes!")

--- a/test_list_as_arg.py
+++ b/test_list_as_arg.py
@@ -1,0 +1,12 @@
+import streamlit as st
+
+from annotated_text import *
+
+annot_text = ["This ", ("is", "verb", "#8ef"), " some ", 
+            ("annotated", "adj", "#faa"), ("text", "noun", "#afa"), 
+            " for those of ", ("you", "pronoun", "#fea"), " who ", 
+            ("like", "verb", "#8ef"), " this sort of ", 
+            ("thing", "noun", "#afa"), ]
+
+
+annotated_text(annot_text)


### PR DESCRIPTION
existing code doesn't take a list as an argument. So if a list of annotated elements is given as an argument, exception ("oh noes!") is raised. 

Updated __init__.py to take a list as an argument for annotated_text(). 

To test if this is working have added script **test_list_as_arg.py** . can run using ` streamlit run test_list_as_arg.py`. in the script a list is given as an argument to annotated_text. works fine. 

P.S : this is my first PR, so pardon me if my ignorance of the process reflects anywhere in this process. 