### PR TITLE
added list support

### DIFF
--- a/annotated_text/util.py
+++ b/annotated_text/util.py
@@ -136,7 +136,21 @@ def get_annotated_html(*args):
         elif isinstance(arg, tuple):
             out(annotation(*arg))
 
+        elif isinstance(arg,list):
+            for el in arg:
+                if isinstance(el, str):
+                    out(html.escape(el))
+
+                elif isinstance(el, HtmlElement):
+                    out(el)
+
+                elif isinstance(el, tuple):
+                    out(annotation(*el))
+
+
         else:
             raise Exception("Oh noes!")
 
     return str(out)
+
+


### PR DESCRIPTION
modified util.py to accept list of elements as input. 

so far, elements have to be passed on like below, 

```
annotated_text(
    "This ",    ("is", "verb", "#8ef"),    " some ",    ("annotated", "adj", "#faa"),    ("text", "noun", "#afa"),    " for those of ",
    ("you", "pronoun", "#fea"),    " who ",    ("like", "verb", "#8ef"),    " this sort of ",    ("thing", "noun", "#afa"),    "."
)

```
with this PR, we can pass a list
```
any_list =    ["This ",   ("is", "verb", "#8ef"),    " some ",    ("annotated", "adj", "#faa"),    ("text", "noun", "#afa"),    " for those of ",    ("you", "pronoun", "#fea"),     " who ",    ("like", "verb", "#8ef"),    " this sort of ",    ("thing", "noun", "#afa"),    "."]

annotated_text(any_list)
```