### PR TITLE
Newlines fix, add support multiline labels

### DIFF
--- a/annotated_text/__init__.py
+++ b/annotated_text/__init__.py
@@ -3,7 +3,7 @@ from . import util
 
 annotation = util.annotation
 
-def annotated_text(*args):
+def annotated_text(*args, newline_mode="old"):
     """Writes text with annotations into your Streamlit app.
 
     Parameters
@@ -43,6 +43,6 @@ def annotated_text(*args):
 
     """
     st.markdown(
-        util.get_annotated_html(*args),
+        util.get_annotated_html(*args, newline_mode=newline_mode),
         unsafe_allow_html=True,
     )

--- a/annotated_text/handler.py
+++ b/annotated_text/handler.py
@@ -1,0 +1,60 @@
+from htbuilder import H, styles
+import html
+
+span = H.span
+
+import annotated_text.parameters as p
+
+default_style_args = dict(display="inline-flex",
+                flex_direction="row",
+                align_items="center",
+                border_radius=p.BORDER_RADIUS,
+                padding=p.PADDING,
+                overflow="hidden",
+                line_height=1,)
+
+
+def map_strategy(body, newline_mode, background, color_style, style, label_element):
+    '''Maps options to newline handling versions'''
+    mapping={'old' : wrap_with_default_flex,
+             'flex': newlines_to_br,
+             'multiline': multiline
+    }
+
+    return mapping[newline_mode](body, background, color_style, style, label_element)
+
+def style_and_span(out, background, color_style, style, label_element):
+    '''Universal output span formater'''
+    merged_styles = {**default_style_args, 
+                     'background-color':background , 
+                     **color_style, 
+                     **style}
+    return (
+        span(
+            style=styles(**merged_styles),
+        )(
+        out,
+        label_element,
+        )
+    )
+
+def wrap_with_default_flex(body, background, color_style, style, label_element):
+    '''Default behavior without newlines processing'''
+    out = html.escape(body)
+    return style_and_span(out, background, color_style, style, label_element)
+        
+def newlines_to_br(body, background, color_style, style, label_element):
+    '''Preprocess newlines to HTML complatible form with replace'''
+    body_new=H.raw(html.escape(body).replace("\n", "<br>"))
+    return style_and_span(body_new, background, color_style, style, label_element)  
+    
+def multiline(body, background, color_style, style, label_element):
+    '''Split to separate lines by \n with inline display'''
+    parts = body.split("\n")
+    style_new = {**default_style_args, 'display': "inline", **style}
+    spans = [style_and_span(part, background, color_style, style_new, '') for part in parts[:-1]]
+    spans.append(style_and_span(parts[-1], background, color_style, style_new, label_element))
+    
+    content = H.raw("<br>".join([str(s) for s in spans]))
+    
+    return span()(content, '')


### PR DESCRIPTION
Currently first newline is ignored and 2nd and more breaks background both for content and label (with or without spaces between)

[Pic1 Example from #21  few text old/current version]
<img src="https://github.com/tvst/st-annotated-text/assets/20603530/4bdf02f8-5cb8-4727-bd80-e27dc967837a" width="200">


This commit adds the argument "newline_mode"
with options:
**1) 'old'** (default) - As is now: ignores first consequential \n, breaks background on second. Nothing changed.

[Pic2 Lots of text old/current version]
<img src="https://github.com/tvst/st-annotated-text/assets/20603530/6b6883ff-6a4e-4b5b-ab2d-13a6d7f650f2" width="500">

**2) 'flex'** - Writes all newlines. Background fixed for both label and content. Each annotation is grouped in box having same label on the side (as side effect of display inline-flex preserved)

[Pic3 Few text flex option]
<img src="https://github.com/tvst/st-annotated-text/assets/20603530/71adae30-3f0f-4ced-8bba-8baf8453a042" width="170">

[Pic4 Lots of text flex option]
<img src="https://github.com/tvst/st-annotated-text/assets/20603530/75c220d8-f42c-41b7-95cd-b0c8740763cf" width="480">

**3) 'multiline'** - writes all newlines with proper background for content. Lines are preserved (by display inline instead of inline-flex).

[Pic5 Few text multiline option]
<img src="https://github.com/tvst/st-annotated-text/assets/20603530/d21f5bd9-10c9-4a57-b59a-037f813ee25b" width="170">
[Pic6 Lots of text multiline option]
<img src="https://github.com/tvst/st-annotated-text/assets/20603530/08b9566c-5a38-47db-a46d-246771df39bf" width="500">


Default behavior is the old one thus it backward-compatible. 
It resolves #21 and gives newline handling in unified and predictable fashion.

 