### PR TITLE
ci: make pycafe link on each commit / playground

### DIFF
--- a/.github/pycafe-create-status.py
+++ b/.github/pycafe-create-status.py
@@ -1,0 +1,50 @@
+import os
+import sys
+from urllib.parse import quote
+
+from github import Github
+
+# Authenticate with GitHub
+access_token = os.getenv("GITHUB_TOKEN")
+g = Github(access_token)
+
+
+repo_name = "tvst/st-annotated-text"
+commit_sha = sys.argv[1]  # e.g d39677a321bca34df41ecc87ff7e539b450207f2
+run_id = sys.argv[2]  # e.g 1324, usually obtained via ${{ github.run_id }} or ${{ github.event.workflow_run.id }} in GitHub Actions workflow files
+type = "streamlit"  # streamlit/dash/vizro/solara/panel
+
+# take the code from the PR/commit, not master
+code = f"https://github.com/tvst/st-annotated-text/raw/{commit_sha}/example.py"
+
+artifact_name = "st-annotated-text-wheel"  # name given in the GitHub Actions workflow file for the artifact
+
+
+# parse the version from the setup.py file, i.e.
+#    version="4.0.1",
+
+path = "setup.py"
+import re
+content = open(path).read()
+version = re.search(r'version="(.*)",', content).group(1)
+print(f"Version: {version}")
+
+requirements = f"""
+https://py.cafe/gh/artifact/{repo_name}/actions/runs/{run_id}/{artifact_name}/st_annotated_text-{version}-py3-none-any.whl
+"""
+
+# GitHub Python API
+repo = g.get_repo(repo_name)
+
+base_url = f"https://py.cafe/snippet/{type}/v1"
+url = f"{base_url}#code={quote(code)}&requirements={quote(requirements)}"
+
+# Define the deployment status
+state = "success"  # Options: 'error', 'failure', 'pending', 'success'
+description = "Test out this PR on a PyCafe playground environment"
+context = "PyCafe"
+
+# Create the status on the commit
+commit = repo.get_commit(commit_sha)
+commit.create_status(state="success", target_url=url, description=description, context="PyCafe")
+print(f"Deployment status added to commit {commit_sha}")

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
+      - name: Build package
+        run: |
+          python setup.py sdist bdist_wheel
+
+      - name: Upload builds
+        uses: actions/upload-artifact@v4
+        with:
+          name: st-annotated-text-wheel
+          path: |
+            ./dist

--- a/.github/workflows/pycafe.yml
+++ b/.github/workflows/pycafe.yml
@@ -1,0 +1,20 @@
+---
+name: PyCafe Playground Link
+on:
+  workflow_run:
+    workflows: [Build]
+    types:
+      - completed
+
+jobs:
+  create-status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Create PyCafe status link
+        run: |
+          pip install PyGithub
+          python .github/pycafe-create-status.py ${{ github.event.workflow_run.head_sha }} ${{ github.event.workflow_run.id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hi Thiago :wave:,

This PR adds two github actions that together set up a Python/Streamlit playground with the latest `st-annotated-text`.

1. *build.yml*: build the source distribution into a github artifact
2. *pycafe.yml*: creates a snippet link to a [PyCafe streamlit app](https://py.cafe/docs/apps/streamlit) that will install the wheel from 1. into a fresh in-browser Python environment and puts it as a status text (what you normally see next to a commit or at the bottom or a PR).

This process is [documented here](https://py.cafe/docs/use-cases/developers#create-a-status-link) for one of our libraries. But I wanted to try it out on a streamlit project, and this one was easy to build.

I've tested this out on https://github.com/maartenbreddels/st-annotated-text/pull/1 to see if it works. It does, and it generates a link in the status:
<img width="1286" alt="image" src="https://github.com/user-attachments/assets/492874b5-c5de-425b-b89e-943e58e14c12">

Which should bring you [to this playground](https://py.cafe/snippet/streamlit/v1#code=https%3A//github.com/tvst/st-annotated-text/raw/e07209d9fde40c30fafb10f6d6da01f601089559/example.py&requirements=%0Ahttps%3A//py.cafe/gh/artifact/maartenbreddels/st-annotated-text/actions/runs/11667400053/st-annotated-text-wheel/st_annotated_text-4.0.1-py3-none-any.whl%0A)


The reason that this is not one GitHub action, but two is due to security. The build.yml runs with the permission of the person opening the PR (and thus cannot write the status text). The pycafe.yml workflow runs with your permission (it can write the status text), but run on your master branch (so it does not execute a modified workflow files).

This is super useful for trying out a branch when someone opens a PR, nothing to install, no server running in the background 🍃  and no costs.

Let me know what you think.

Regards,

Maarten

PS: this PR does not write the status text yet, because pycafe.yml should be merged first before it runs, that's why I've created https://github.com/maartenbreddels/st-annotated-text/pull/1 to show that it works.